### PR TITLE
Update twitter link to point to new username

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -35,7 +35,7 @@ disqus:
 
 # if you don't have any of social below, comment the line
 facebook: ZainDov
-twitter: ZainSWE
+twitter: _zainp
 # google: mygoogle
 # instagram: myinstagram
 # pinterest: mypinterest


### PR DESCRIPTION
This PR updates the twitter social link to point to the updated username.